### PR TITLE
14 digit timestamp on XML sample.

### DIFF
--- a/2050-084X_2013_elife01856.xml
+++ b/2050-084X_2013_elife01856.xml
@@ -7,7 +7,7 @@
 	xmlns:mml="http://www.w3.org/1998/Math/MathML">
 		<head>
 			<doi_batch_id>elife-2014-01-01-110000-PoA</doi_batch_id>
-		<timestamp>1388574000</timestamp>
+		<timestamp>20140101110000</timestamp>
 		<depositor>
 			<name>eLife</name>
 			<email_address>production@elifesciences.org</email_address>


### PR DESCRIPTION
Corrected timestamp format, to be 14 digits, not a UNIX timestamp value.
